### PR TITLE
Generate Telemetry Unit Labels Function

### DIFF
--- a/aprslib/packets/__init__.py
+++ b/aprslib/packets/__init__.py
@@ -1,1 +1,2 @@
 from aprslib.packets.position import PositionReport
+from aprslib.packets.telemetry import TelemetryReport

--- a/aprslib/packets/__init__.py
+++ b/aprslib/packets/__init__.py
@@ -1,2 +1,3 @@
 from aprslib.packets.position import PositionReport
 from aprslib.packets.telemetry import TelemetryReport
+from aprslib.packets.telemetryunitlabels import TelemetryUnitLabelsReport

--- a/aprslib/packets/telemetry.py
+++ b/aprslib/packets/telemetry.py
@@ -1,0 +1,32 @@
+from aprslib.packets.base import APRSPacket
+
+class TelemetryReport(APRSPacket):
+    format = 'raw'
+    sequenceno = 0
+    analog1 = 0
+    analog2 = 0
+    analog3 = 0
+    analog4 = 0
+    analog5 = 0
+    digitalvalue = ['0']*8
+    comment = ''
+
+    def _serialize_body(self):
+        # What do we do when len(digitalvalue) != 8?
+        self.digitalvalue = ''.join(self.digitalvalue)
+
+        body = [
+            'T#',  # packet type
+            str(self.sequenceno).zfill(3),
+            str(self.analog1).zfill(3),
+            str(self.analog2).zfill(3),
+            str(self.analog3).zfill(3),
+            str(self.analog4).zfill(3),
+            str(self.analog5).zfill(3),
+            str(self.digitalvalue),
+            self.comment,
+        ]
+        tmpbody = ",".join(body)
+
+        # remove static but erroneous comma between T# and sequenceno
+        return tmpbody[:2] + tmpbody[3:]

--- a/aprslib/packets/telemetryunitlabels.py
+++ b/aprslib/packets/telemetryunitlabels.py
@@ -16,7 +16,6 @@ class TelemetryUnitLabelsReport(APRSPacket):
     b6 = "EN"
     b7 = "EN"
     b8 = "EN"
-    comment = ''
 
     def _serialize_body(self):
 
@@ -40,4 +39,5 @@ class TelemetryUnitLabelsReport(APRSPacket):
         badcomma = tmpbody.index(",")
 
         # remove static but erroneous comma between UNIT. and a1 value
+        # Position can vary due to callsign
         return tmpbody[:badcomma] + tmpbody[badcomma+1:]

--- a/aprslib/packets/telemetryunitlabels.py
+++ b/aprslib/packets/telemetryunitlabels.py
@@ -1,0 +1,43 @@
+from aprslib.packets.base import APRSPacket
+
+class TelemetryUnitLabelsReport(APRSPacket):
+    format = 'raw'
+    telemetrystation = "N0CALL"
+    a1 = "BITS"
+    a2 = "BITS"
+    a3 = "BITS"
+    a4 = "BITS"
+    a5 = "BITS"
+    b1 = "EN"
+    b2 = "EN"
+    b3 = "EN"
+    b4 = "EN"
+    b5 = "EN"
+    b6 = "EN"
+    b7 = "EN"
+    b8 = "EN"
+    comment = ''
+
+    def _serialize_body(self):
+
+        body = [
+            ':{0} :UNIT.'.format(self.telemetrystation),  # packet type
+            self.a1,
+            self.a2,
+            self.a3,
+            self.a4,
+            self.a5,
+            self.b1,
+            self.b2,
+            self.b3,
+            self.b4,
+            self.b5,
+            self.b6,
+            self.b7,
+            self.b8,
+        ]
+        tmpbody = ",".join(body)
+        badcomma = tmpbody.index(",")
+
+        # remove static but erroneous comma between UNIT. and a1 value
+        return tmpbody[:badcomma] + tmpbody[badcomma+1:]


### PR DESCRIPTION
I branched from PR #27 commit to add a Telemetry Unit Label Function. This allows one to add unit labels to APRS telemetry. I checked this operation on APRS-IS.

APRS Specification:
![image](https://cloud.githubusercontent.com/assets/331540/23826192/33e70e96-064c-11e7-8b45-7984f0717fd5.png)

APRS.fi accepted string test:
![image](https://cloud.githubusercontent.com/assets/331540/23826187/0630c546-064c-11e7-8e92-88c64fc708f0.png)

Let me know if this should be rolled into #27 instead. Figured I'd keep the PR's separate for new packets.