### PR TITLE
Let consumer surpress lines starting with # in Python3.

### DIFF
--- a/aprslib/inet.py
+++ b/aprslib/inet.py
@@ -178,9 +178,9 @@ class IS(object):
         while True:
             try:
                 for line in self._socket_readlines(blocking):
-                    if line[0] != "#":
+                    if line[0].decode('UTF-8') != "#":
                         if raw:
-                            callback(line)
+                            callback(line.decode('UTF-8'))
                         else:
                             callback(self._parse(line))
                     else:


### PR DESCRIPTION
Python3 receives the APRS lines as byte strings, not UTF-8 strings.
See also: https://stackoverflow.com/a/6273618/2192488