### PR TITLE
Fix error in adding APRS paths to the string

### DIFF
--- a/aprslib/packets/base.py
+++ b/aprslib/packets/base.py
@@ -30,7 +30,7 @@ class APRSPacket(object):
         header = "%s>%s" % (self.fromcall, self.tocall)
 
         if self.path:
-            header += "," + ",".join(self.path)
+            header += "," + self.path
 
         return header
 


### PR DESCRIPTION
Before print(str(pkt)) would produce:
N0CALL>N0CALL,W,I,D,E,2,-,1:!0000.00N/00000.00El

After the fix print(str(pkt)) produces the correct string:
N0CALL>N0CALL,WIDE2-1:!0000.00N/00000.00El