### PR TITLE
Third party packet support

### DIFF
--- a/aprslib/parsing/__init__.py
+++ b/aprslib/parsing/__init__.py
@@ -116,6 +116,7 @@ def parse(packet):
     # capture ParseErrors and attach the packet
     except (UnknownFormat, ParseError) as exp:
         exp.packet = packet
+        exp.parsed = parsed
         raise
 
     # if we fail all attempts to parse, try beacon packet

--- a/aprslib/parsing/__init__.py
+++ b/aprslib/parsing/__init__.py
@@ -138,6 +138,26 @@ def parse(packet):
 def _try_toparse_body(packet_type, body, parsed):
     result = {}
 
+    unsupported_formats = {
+            '#':'raw weather report',
+            '$':'raw gps',
+            '%':'agrelo',
+            '&':'reserved',
+            '(':'unused',
+            ')':'item report',
+            '*':'complete weather report',
+            '+':'reserved',
+            '-':'unused',
+            '.':'reserved',
+            '<':'station capabilities',
+            '?':'general query format',
+            'T':'telemetry report',
+            '[':'maidenhead locator beacon',
+            '\\':'unused',
+            ']':'unused',
+            '^':'unused',
+            '}':'3rd party traffic'
+    }
     # NOT SUPPORTED FORMATS
     #
     # # - raw weather report
@@ -159,7 +179,7 @@ def _try_toparse_body(packet_type, body, parsed):
     # ^ - unused
     # } - 3rd party traffic
     if packet_type in '#$%)*<?T[}':
-        raise UnknownFormat("format is not supported")
+        raise UnknownFormat('format is not supported: {0}'.format(unsupported_formats[packet_type]))
 
     # user defined
     elif packet_type == ',':

--- a/aprslib/parsing/__init__.py
+++ b/aprslib/parsing/__init__.py
@@ -42,6 +42,7 @@ from aprslib.parsing.mice import *
 from aprslib.parsing.message import *
 from aprslib.parsing.telemetry import *
 from aprslib.parsing.weather import *
+from aprslib.parsing.thirdparty import *
 
 
 def _unicode_packet(packet):
@@ -157,7 +158,6 @@ def _try_toparse_body(packet_type, body, parsed):
             '\\':'unused',
             ']':'unused',
             '^':'unused',
-            '}':'3rd party traffic'
     }
     # NOT SUPPORTED FORMATS
     #
@@ -178,9 +178,14 @@ def _try_toparse_body(packet_type, body, parsed):
     # \ - unused
     # ] - unused
     # ^ - unused
-    # } - 3rd party traffic
-    if packet_type in '#$%)*<?T[}':
+    if packet_type in '#$%)*<?T[':
         raise UnknownFormat('format is not supported: {0}'.format(unsupported_formats[packet_type]))
+
+    # third party
+    elif packet_type == '}':
+        logger.debug("Packet is third-party")
+
+        body, result = parse_thirdparty(body)
 
     # user defined
     elif packet_type == ',':

--- a/aprslib/parsing/thirdparty.py
+++ b/aprslib/parsing/thirdparty.py
@@ -1,0 +1,21 @@
+import re
+from aprslib.parsing.__init__ import parse
+from aprslib.exceptions import UnknownFormat
+from aprslib.exceptions import ParseError
+
+__all__ = [
+        'parse_thirdparty',
+        ]
+
+def parse_thirdparty(body):
+    parsed = {'format':'Third party'}
+
+    # Parse sub-packet
+    try:
+        subpacket = parse(body)
+    except (UnknownFormat) as ukf:
+        subpacket = ukf.parsed
+
+    parsed.update({'subpacket':subpacket})
+
+    return('',parsed)


### PR DESCRIPTION
Added support for third-party packets, where the body is itself a packet.

The sub-packet is parsed, and its dictionary is returned as the 'subpacket' value of the main packet.  Unsupported third-party packets are parsed to the extent possible.
Error handling could probably be improved, particularly for parse errors.