### PR TITLE
Add function to clean WIDEn-N and * from path, leaving just digi callsigns

### DIFF
--- a/aprslib/parsing/common.py
+++ b/aprslib/parsing/common.py
@@ -62,6 +62,7 @@ def parse_header(head):
         'from': fromcall,
         'to': tocall,
         'path': path,
+        'digipath': digipath,
         }
 
     viacall = ""
@@ -71,6 +72,21 @@ def parse_header(head):
     parsed.update({'via': viacall})
 
     return parsed
+
+
+def remove_WIDEn_N(path):
+    """
+    Remove WIDEn-N entries and * markers from path, leaving only digi names
+    path: path of parsed packet (list of strings)
+    returns: list of digipeaters that digipeated packet, in order
+    """
+    digipath = []
+    for digi in path:
+        digi = re.sub('\*','',digi) # Get rid of * markers
+        if not re.match('WIDE[0-9]-*[0-9]*',digi): # check for not WIDEn-N
+            digipath.append(digi)
+
+    return digipath
 
 
 def parse_timestamp(body, packet_type=''):

--- a/aprslib/parsing/common.py
+++ b/aprslib/parsing/common.py
@@ -62,7 +62,6 @@ def parse_header(head):
         'from': fromcall,
         'to': tocall,
         'path': path,
-        'digipath': digipath,
         }
 
     viacall = ""


### PR DESCRIPTION
Added a function to turn a digi path list into a list of digis through which the packet passed.
Path: `['K0ABC-1','WIDE1*','W0DEF-2','N0GHI-1*']`
becomes digi path: `['K0ABC-1','W0DEF-2','N0GHI-1']`
This is useful for anyone interested in getting just the digipeaters in the path without the extraneous routing info.