### PR TITLE
Removed trailing characters from PHG field

### DIFF
--- a/aprslib/parsing/common.py
+++ b/aprslib/parsing/common.py
@@ -151,7 +151,7 @@ def parse_data_extentions(body):
             if nrq.isdigit():
                 parsed.update({'nrq': int(nrq)})
     else:
-        match = re.findall(r"^(PHG(\d[\x30-\x7e]\d\d[0-9A-Z]?))", body)
+        match = re.findall(r"^(PHG(\d[\x30-\x7e]\d\d))", body)
         if match:
             ext, phg = match[0]
             body = body[len(ext):]


### PR DESCRIPTION
According to spec, we are looking for PHGxyxx where x is a digit 0-9 and y is 0 and higher ASCII.  There were issues when the following character was [0-9A-Z] and the spec points out that this is a 7-character data extension.