### PR TITLE
Allow read empty socket in nonblocking mode on win32

### DIFF
--- a/aprslib/inet.py
+++ b/aprslib/inet.py
@@ -339,7 +339,7 @@ class IS(object):
                    and not blocking
                    and len(self.buf) == 0):
                         break
-                elif ("WinError 10035" in str(e) 
+                elif ("WinError 10035" in str(e)  
                         and not blocking 
                         and "win32" in sys.platform):
                     break

--- a/aprslib/inet.py
+++ b/aprslib/inet.py
@@ -22,6 +22,7 @@ import socket
 import select
 import time
 import logging
+import sys
 
 from aprslib import __version__, string_type, is_py3
 from aprslib.parsing import parse
@@ -338,6 +339,10 @@ class IS(object):
                    and not blocking
                    and len(self.buf) == 0):
                         break
+                elif ("WinError 10035" in str(e) 
+                        and not blocking 
+                        and "win32" in sys.platform):
+                    break
                 else:
                     self.logger.error("socket error on recv(): %s" % str(e))
 

--- a/aprslib/inet.py
+++ b/aprslib/inet.py
@@ -22,6 +22,7 @@ import socket
 import select
 import time
 import logging
+import sys
 
 from aprslib import __version__, string_type, is_py3
 from aprslib.parsing import parse
@@ -338,6 +339,8 @@ class IS(object):
                    and not blocking
                    and len(self.buf) == 0):
                         break
+                elif ("WinError 10035"  in str(e) and not blocking and "win32" in sys.platform):
+                    break
                 else:
                     self.logger.error("socket error on recv(): %s" % str(e))
 


### PR DESCRIPTION
Hi. I do development on windows but prod goes on *nix.

This is a small improvement on [8674bbd](https://github.com/rossengeorgiev/aprs-python/commit/8674bbd1436207e6e6f475a337e6e857790744bb) which should allow non-blocking sockets to not spam errors on win32 systems, as originally described by in [issue 57](https://github.com/rossengeorgiev/aprs-python/issues/57).

Thanks for the lib, 73.

+ edit: minor fix to make sonarcloud happy