### PR TITLE
Better support for the reply-ack mechanism

### DIFF
--- a/aprslib/parsing/message.py
+++ b/aprslib/parsing/message.py
@@ -92,6 +92,8 @@ def parse_message(body):
         match = re.findall(r"^(ack|rej)([A-Za-z0-9]{2})}([A-Za-z0-9]{2})?$", body)
         if match:
             parsed['response'], parsed['msgNo'], ackMsgNo = match[0]
+            parsed['msgNo101'] = parsed['msgNo'] + "}" + ackMsgNo
+            parsed['isReplyAck'] = True
             if ackMsgNo:
                 parsed['ackMsgNo'] = ackMsgNo
             break
@@ -101,6 +103,7 @@ def parse_message(body):
         match = re.findall(r"^(ack|rej)([A-Za-z0-9]{1,5})$", body)
         if match:
             parsed['response'], parsed['msgNo'] = match[0]
+            parsed['msgNo101'] = parsed['msgNo']
             break
 
         # regular message body parser
@@ -113,8 +116,11 @@ def parse_message(body):
         match = re.findall(r"{([A-Za-z0-9]{2})}([A-Za-z0-9]{2})?$", body)
         if match:
             msgNo, ackMsgNo = match[0]
+            msgNo101 = msgNo + "}" + ackMsgNo
             parsed['message_text'] = body[:len(body) - 4 - len(ackMsgNo)].strip(' ')
             parsed['msgNo'] = msgNo
+            parsed['msgNo101'] = msgNo101
+            parsed['isReplyAck'] = True
             if ackMsgNo:
                 parsed['ackMsgNo'] = ackMsgNo
             break
@@ -126,6 +132,7 @@ def parse_message(body):
             msgNo = match[0]
             parsed['message_text'] = body[:len(body) - 1 - len(msgNo)].strip(' ')
             parsed['msgNo'] = msgNo
+            parsed['msgNo101'] = msgNo
             break
 
         # break free from the eternal 'while'

--- a/tests/test_parse_message_rejack.py
+++ b/tests/test_parse_message_rejack.py
@@ -23,6 +23,7 @@ class AckRejTests(unittest.TestCase):
             'format': 'message',
             'addresse': 'WXBOT',
             'msgNo': '123',
+            'msgNo101': '123',
             'response': 'rej'
         }
 
@@ -37,6 +38,8 @@ class AckRejTests(unittest.TestCase):
             'addresse': 'WXBOT',
             'response': 'ack',
             'msgNo': 'AB',
+            'msgNo101': 'AB}',
+            'isReplyAck': True,
         }
 
         self.assertEqual(unparsed, '')
@@ -50,7 +53,9 @@ class AckRejTests(unittest.TestCase):
             'addresse': 'WXBOT',
             'response': 'ack',
             'msgNo': 'AB',
+            'msgNo101': 'AB}CD',
             'ackMsgNo': 'CD',
+            'isReplyAck': True,
         }
 
         self.assertEqual(unparsed, '')
@@ -79,6 +84,7 @@ class MessageTestBodyTests(unittest.TestCase):
             'addresse': 'WXBOT',
             'message_text': 'HelloWorld',
             'msgNo': 'ABCDE',
+            'msgNo101': 'ABCDE',
         }
 
         self.assertEqual(unparsed, '')
@@ -92,6 +98,8 @@ class MessageTestBodyTests(unittest.TestCase):
             'addresse': 'WXBOT',
             'message_text': 'HelloWorld',
             'msgNo': 'AB',
+            'msgNo101': 'AB}',
+            'isReplyAck': True,
         }
 
         self.assertEqual(unparsed, '')
@@ -105,7 +113,9 @@ class MessageTestBodyTests(unittest.TestCase):
             'addresse': 'WXBOT',
             'message_text': 'HelloWorld',
             'msgNo': 'AB',
+            'msgNo101': 'AB}CD',
             'ackMsgNo': 'CD',
+            'isReplyAck': True,
         }
 
         self.assertEqual(unparsed, '')


### PR DESCRIPTION
The reply-ack mechanism is intended to be backwards compatible with APRS 1.01. The current implementation of reply-ack parsing makes it difficult to ack messages sent from clients that support reply-ack.

There are three rules in `reply-ack` that require the entire string after the `{` to be accessible.

http://www.aprs.org/aprs11/replyacks.txt

> 3) RECEIVE messages and Strip off the AA from the end of the message text
>    before you store it.  THis is necessary so that your DUPE checker will
>    still work.  Since the AA may be different for multiple copies of the
>    same incoming MM...
> 4) When you receive a message line XXX.., send the normal existing
>    "ackXXX..". This algoirithm is unchanged.  Even if XXX.. is MM}AA
>    then the ack is just the exact copy as before "ackMM}AA".
> 5) When you receive a message line MM}AA, do 4 above as normal, but
>    also then save the incoming MM number as now it is your "latest ACK"
>    for that station.  Now then this becomes the AA REPLY-ACK number for
>    your next outgoing message to that station. (Step 1 above).

If we look at the parsed data, we will see that following rule 4 is a little difficult. Aside from looking at the `raw` value, there's nothing that indicates that I should send `ackMU}` instead of `ackMU` when acknowledging this message according to rule 4.

```py
{'addresse': 'K3FNB-1',
 'format': 'message',
 'from': 'K3FNB-2',
 'message_text': 'from aprsis32',
 'msgNo': 'MU',
 'path': ['TCPIP*', 'qAC', 'T2CSNGRAD'],
 'raw': 'K3FNB-2>APWW11,TCPIP*,qAC,T2CSNGRAD::K3FNB-1  :from aprsis32{MU}AA',
 'to': 'APWW11',
 'via': 'T2CSNGRAD'}
```

This change modifies the parsed data in the following way:

```
 'msgNo': 'MU',
+ 'msgNo101': 'MU}AA',
+ 'isReplyAck': true,
 'raw': 'K3FNB-2>APWW11,TCPIP*,qAC,T2CSNGRAD::K3FNB-1  :from aprsis32{MU}',
```

`msgNo101` is the full string of the message number as if it was parsed by an APRS 1.01 client. This allows us to easily ack the message by just following rule 4 with the `msgNo101` value.

`isReplyAck` tells us that the client that sent the message supports reply-ack. This tells an application to follow rule 3 for deduping and that the application can use the reply-ack mechanism for acknowledgments.