### PR TITLE
Use r-string for regexp to stop SyntaxWarning

### DIFF
--- a/aprslib/parsing/common.py
+++ b/aprslib/parsing/common.py
@@ -215,7 +215,7 @@ def parse_comment_altitude(body):
 
 
 def parse_dao(body, parsed):
-    match = re.findall("^(.*)\!([\x21-\x7b])([\x20-\x7b]{2})\!(.*?)$", body)
+    match = re.findall(r"^(.*)\!([\x21-\x7b])([\x20-\x7b]{2})\!(.*?)$", body)
     if match:
         body, daobyte, dao, rest = match[0]
         body += rest


### PR DESCRIPTION
Python issues a warning about regexp escape characters in a regular string. Changing the string to a regexp string stops the warnings.